### PR TITLE
Use environment variables to run/ignore real tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ event := NewEvent(headersMap, body)
 client.Append(event)
 ```
 
+## Development
+
+Clone the repository and do the following sequence of command:
+```bash
+go get
+go test ./...
+```
+
+To run test with a real client run the following command:
+```bash
+FLUME_SERVER_ADDRESS=127.0.0.1:20201 go test -count=1 -run TestSend
+```
+where `127.0.0.1:20201` is a real Apache Flume server, `-count=1` is a way to disable Go build cache.
+
 ## License
 
 Open source licensed under the MIT license (see _LICENSE_ file for details).

--- a/ipc_test.go
+++ b/ipc_test.go
@@ -2,15 +2,20 @@ package avroipc
 
 import (
 	"log"
+	"os"
 	"testing"
 )
 
 func TestSend(t *testing.T) {
-	t.Skip("Skip the real test")
 	log.SetFlags(log.LstdFlags | log.Lshortfile)
 
+	addr := os.Getenv("FLUME_SERVER_ADDRESS")
+	if addr == "" {
+		t.Skip("The FLUME_SERVER_ADDRESS environment variable is not set")
+	}
+
 	// flume avro instance address
-	client := NewClient("localhost:20200")
+	client := NewClient(addr)
 
 	headersMap := make(map[string]string)
 	headersMap["topic"] = "myzhan"


### PR DESCRIPTION
Use environment variables to run/ignore tests with a real Apache Flume server.

Additionally, the documentation was updated to show a way to run test with the real client.