### PR TITLE
Limit execution time of client methods, close #15

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ import (
 
 func main() {
     // flume avro instance address
-    client, err := avroipc.NewClient("localhost:20200", 1024, 6)
+    client, err := avroipc.NewClient("localhost:20200", 0, 1024, 6)
     if err != nil {
         log.Fatal(err)
     }

--- a/buffered_transport.go
+++ b/buffered_transport.go
@@ -2,6 +2,7 @@ package avroipc
 
 import (
 	"bufio"
+	"time"
 )
 
 type bufferedTransport struct {
@@ -40,4 +41,8 @@ func (p *bufferedTransport) Flush() error {
 		return err
 	}
 	return p.trans.Flush()
+}
+
+func (p *bufferedTransport) SetDeadline(t time.Time) error {
+	return p.trans.SetDeadline(t)
 }

--- a/buffered_transport_test.go
+++ b/buffered_transport_test.go
@@ -2,11 +2,13 @@ package avroipc_test
 
 import (
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/myzhan/avroipc"
 	"github.com/myzhan/avroipc/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func prepareBufferedTransport() (avroipc.Transport, *mocks.MockTransport) {
@@ -239,4 +241,15 @@ func TestBufferedTransport_Flush(t *testing.T) {
 		require.EqualError(t, err, "test error")
 		m.AssertExpectations(t)
 	})
+}
+
+func TestBufferedTransport_SetDeadline(t *testing.T) {
+	d := time.Now()
+	b, m := prepareBufferedTransport()
+
+	m.On("SetDeadline", d).Return(nil).Once()
+
+	err := b.SetDeadline(d)
+	require.NoError(t, err)
+	m.AssertExpectations(t)
 }

--- a/framing.go
+++ b/framing.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"time"
 )
 
 const maxFrameSize = 10 * 1024
@@ -15,6 +16,8 @@ type FramingLayer interface {
 	Write(p []byte) error
 
 	Close() error
+
+	SetDeadline(t time.Time) error
 }
 
 // Framing is a part on the Avro RPC protocol.
@@ -135,4 +138,8 @@ func (f *framingLayer) writeFrames(p []byte) (err error) {
 
 func (f *framingLayer) Close() error {
 	return f.trans.Close()
+}
+
+func (f *framingLayer) SetDeadline(d time.Time) error {
+	return f.trans.SetDeadline(d)
 }

--- a/framing_test.go
+++ b/framing_test.go
@@ -3,11 +3,13 @@ package avroipc_test
 import (
 	"bytes"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/myzhan/avroipc"
 	"github.com/myzhan/avroipc/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func prepareFramingLayer() (avroipc.FramingLayer, *mocks.MockTransport) {
@@ -204,7 +206,7 @@ func TestFramingLayer_Write(t *testing.T) {
 }
 
 func TestFramingLayer_Close(t *testing.T) {
-	t.Run("success", func(t *testing.T) {
+	t.Run("succeed", func(t *testing.T) {
 		f, m := prepareFramingLayer()
 
 		m.On("Close").Return(nil).Once()
@@ -223,4 +225,15 @@ func TestFramingLayer_Close(t *testing.T) {
 		require.EqualError(t, err, "test error")
 		m.AssertExpectations(t)
 	})
+}
+
+func TestFramingLayer_SetDeadline(t *testing.T) {
+	d := time.Now()
+	f, m := prepareFramingLayer()
+
+	m.On("SetDeadline", d).Return(nil).Once()
+
+	err := f.SetDeadline(d)
+	require.NoError(t, err)
+	m.AssertExpectations(t)
 }

--- a/ipc_test.go
+++ b/ipc_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -26,9 +27,10 @@ func TestSend(t *testing.T) {
 	}
 
 	bufferSize := 8
+	sendTimeout := time.Duration(0)
 
 	// flume avro instance address
-	client, err := NewClient(addr, bufferSize, levelInt)
+	client, err := NewClient(addr, sendTimeout, bufferSize, levelInt)
 	require.NoError(t, err)
 
 	event := &Event{

--- a/mocks/framing.go
+++ b/mocks/framing.go
@@ -1,6 +1,8 @@
 package mocks
 
 import (
+	"time"
+
 	"github.com/stretchr/testify/mock"
 )
 
@@ -20,5 +22,10 @@ func (f *MockFramingLayer) Write(p []byte) error {
 
 func (f *MockFramingLayer) Close() error {
 	args := f.Called()
+	return args.Error(0)
+}
+
+func (f *MockFramingLayer) SetDeadline(t time.Time) error {
+	args := f.Called(t)
 	return args.Error(0)
 }

--- a/mocks/transport.go
+++ b/mocks/transport.go
@@ -2,6 +2,7 @@ package mocks
 
 import (
 	"github.com/stretchr/testify/mock"
+	"time"
 )
 
 type MockTransport struct {
@@ -30,5 +31,10 @@ func (t *MockTransport) Write(p []byte) (n int, err error) {
 
 func (t *MockTransport) Flush() error {
 	args := t.Called()
+	return args.Error(0)
+}
+
+func (t *MockTransport) SetDeadline(d time.Time) error {
+	args := t.Called(d)
 	return args.Error(0)
 }

--- a/socket.go
+++ b/socket.go
@@ -75,3 +75,7 @@ func (s *socket) Write(buf []byte) (int, error) {
 func (s *socket) Flush() error {
 	return nil
 }
+
+func (s *socket) SetDeadline(d time.Time) error {
+	return s.conn.SetDeadline(d)
+}

--- a/transport.go
+++ b/transport.go
@@ -2,6 +2,7 @@ package avroipc
 
 import (
 	"io"
+	"time"
 )
 
 type Transport interface {
@@ -9,4 +10,5 @@ type Transport interface {
 
 	Open() error
 	Flush() error
+	SetDeadline(t time.Time) error
 }

--- a/zlib_transport.go
+++ b/zlib_transport.go
@@ -3,6 +3,7 @@ package avroipc
 import (
 	"compress/zlib"
 	"io"
+	"time"
 )
 
 type zlibTransport struct {
@@ -68,4 +69,8 @@ func (t *zlibTransport) Flush() error {
 	}
 
 	return t.trans.Flush()
+}
+
+func (t *zlibTransport) SetDeadline(d time.Time) error {
+	return t.trans.SetDeadline(d)
 }

--- a/zlib_transport_test.go
+++ b/zlib_transport_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"io"
 	"testing"
+	"time"
 )
 
 var data = []byte{0x78, 0x01, 0x00, 0x04, 0x00, 0xfb, 0xff, 0x74, 0x65, 0x73, 0x74, 0x01, 0x00, 0x00, 0xff, 0xff, 0x04, 0x5d, 0x01, 0xc1}
@@ -25,6 +26,10 @@ func (m *mockTransport) Close() error {
 }
 
 func (m *mockTransport) Flush() error {
+	return nil
+}
+
+func (m *mockTransport) SetDeadline(d time.Time) error {
 	return nil
 }
 

--- a/zlib_transport_test.go
+++ b/zlib_transport_test.go
@@ -3,11 +3,12 @@ package avroipc_test
 import (
 	"bytes"
 	"errors"
-	"github.com/myzhan/avroipc"
-	"github.com/stretchr/testify/require"
 	"io"
 	"testing"
 	"time"
+
+	"github.com/myzhan/avroipc"
+	"github.com/stretchr/testify/require"
 )
 
 var data = []byte{0x78, 0x01, 0x00, 0x04, 0x00, 0xfb, 0xff, 0x74, 0x65, 0x73, 0x74, 0x01, 0x00, 0x00, 0xff, 0xff, 0x04, 0x5d, 0x01, 0xc1}
@@ -29,8 +30,8 @@ func (m *mockTransport) Flush() error {
 	return nil
 }
 
-func (m *mockTransport) SetDeadline(d time.Time) error {
-	return nil
+func (m *mockTransport) SetDeadline(time.Time) error {
+	return errors.New("test error")
 }
 
 func TestZlibTransport_Open(t *testing.T) {
@@ -108,5 +109,15 @@ func TestZlibTransport_Write(t *testing.T) {
 		require.NoError(t, err)
 
 		require.Equal(t, flushed, m.Bytes())
+	})
+	t.Run("set deadline", func(t *testing.T) {
+		d := time.Now()
+		m := &mockTransport{}
+
+		trans, err := avroipc.NewZlibTransport(m, 1)
+		require.NoError(t, err)
+
+		err = trans.SetDeadline(d)
+		require.EqualError(t, err, "test error")
 	})
 }


### PR DESCRIPTION
The simplest way to implement such feature is by using the `SetDealine` feature of the [net.Conn](https://golang.org/pkg/net/#Conn) interface.

So this method should be added to the `Transport` interface and all its implementations.