### PR TITLE
Remove SetDeadline from the framing layer

### DIFF
--- a/client.go
+++ b/client.go
@@ -157,7 +157,7 @@ func (c *client) sendMessage(method string, datum interface{}) (string, error) {
 func (c *client) applyDeadline() error {
 	if c.sendTimeout > 0 {
 		d := time.Now().Add(c.sendTimeout)
-		return c.framingLayer.SetDeadline(d)
+		return c.transport.SetDeadline(d)
 	}
 
 	return nil

--- a/framing.go
+++ b/framing.go
@@ -5,7 +5,6 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
-	"time"
 )
 
 const maxFrameSize = 10 * 1024
@@ -16,8 +15,6 @@ type FramingLayer interface {
 	Write(p []byte) error
 
 	Close() error
-
-	SetDeadline(t time.Time) error
 }
 
 // Framing is a part on the Avro RPC protocol.
@@ -115,7 +112,11 @@ func (f *framingLayer) writeFrames(p []byte) (err error) {
 	}
 
 	for len(p) >= maxFrameSize {
-		binary.Write(f.trans, binary.BigEndian, uint32(maxFrameSize))
+		err = binary.Write(f.trans, binary.BigEndian, uint32(maxFrameSize))
+		if err != nil {
+			return
+		}
+
 		_, err = f.trans.Write(p[:maxFrameSize])
 		if err != nil {
 			return
@@ -138,8 +139,4 @@ func (f *framingLayer) writeFrames(p []byte) (err error) {
 
 func (f *framingLayer) Close() error {
 	return f.trans.Close()
-}
-
-func (f *framingLayer) SetDeadline(d time.Time) error {
-	return f.trans.SetDeadline(d)
 }

--- a/framing_test.go
+++ b/framing_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/myzhan/avroipc"
 	"github.com/myzhan/avroipc/mocks"
@@ -225,15 +224,4 @@ func TestFramingLayer_Close(t *testing.T) {
 		require.EqualError(t, err, "test error")
 		m.AssertExpectations(t)
 	})
-}
-
-func TestFramingLayer_SetDeadline(t *testing.T) {
-	d := time.Now()
-	f, m := prepareFramingLayer()
-
-	m.On("SetDeadline", d).Return(nil).Once()
-
-	err := f.SetDeadline(d)
-	require.NoError(t, err)
-	m.AssertExpectations(t)
 }

--- a/mocks/framing.go
+++ b/mocks/framing.go
@@ -1,8 +1,6 @@
 package mocks
 
 import (
-	"time"
-
 	"github.com/stretchr/testify/mock"
 )
 
@@ -22,10 +20,5 @@ func (f *MockFramingLayer) Write(p []byte) error {
 
 func (f *MockFramingLayer) Close() error {
 	args := f.Called()
-	return args.Error(0)
-}
-
-func (f *MockFramingLayer) SetDeadline(t time.Time) error {
-	args := f.Called(t)
 	return args.Error(0)
 }


### PR DESCRIPTION
The framing layer is not supposed to have any blocking operations or operations which may hang for a long time. So having methods/parameters related to any kind of timeouts or deadlines looks insane and the framing layer should not manage them in any way. It should just reformat written bytes and join bytes before reading.