### PR TITLE
Remove Close from the framing layer

### DIFF
--- a/client.go
+++ b/client.go
@@ -186,5 +186,5 @@ func (c *client) Close() error {
 		return err
 	}
 
-	return c.framingLayer.Close()
+	return c.transport.Close()
 }

--- a/client_internal_test.go
+++ b/client_internal_test.go
@@ -198,22 +198,22 @@ func TestClient_Close(t *testing.T) {
 	testErr := errors.New("test error")
 
 	t.Run("succeed", func(t *testing.T) {
-		c, _, f, _, _ := prepare()
+		c, x, _, _, _ := prepare()
 
-		f.On("Close").Return(nil)
+		x.On("Close").Return(nil)
 
 		err := c.Close()
 		require.NoError(t, err)
-		f.AssertExpectations(t)
+		x.AssertExpectations(t)
 	})
 
 	t.Run("framing layer error", func(t *testing.T) {
-		c, _, f, _, _ := prepare()
+		c, x, _, _, _ := prepare()
 
-		f.On("Close").Return(testErr)
+		x.On("Close").Return(testErr)
 
 		err := c.Close()
 		require.EqualError(t, err, "test error")
-		f.AssertExpectations(t)
+		x.AssertExpectations(t)
 	})
 }

--- a/framing.go
+++ b/framing.go
@@ -11,10 +11,7 @@ const maxFrameSize = 10 * 1024
 
 type FramingLayer interface {
 	Read() ([]byte, error)
-
 	Write(p []byte) error
-
-	Close() error
 }
 
 // Framing is a part on the Avro RPC protocol.
@@ -135,8 +132,4 @@ func (f *framingLayer) writeFrames(p []byte) (err error) {
 	}
 
 	return
-}
-
-func (f *framingLayer) Close() error {
-	return f.trans.Close()
 }

--- a/framing_test.go
+++ b/framing_test.go
@@ -203,25 +203,3 @@ func TestFramingLayer_Write(t *testing.T) {
 		m.AssertExpectations(t)
 	})
 }
-
-func TestFramingLayer_Close(t *testing.T) {
-	t.Run("succeed", func(t *testing.T) {
-		f, m := prepareFramingLayer()
-
-		m.On("Close").Return(nil).Once()
-
-		err := f.Close()
-		require.NoError(t, err)
-		m.AssertExpectations(t)
-	})
-
-	t.Run("failed", func(t *testing.T) {
-		f, m := prepareFramingLayer()
-
-		m.On("Close").Return(fmt.Errorf("test error")).Once()
-
-		err := f.Close()
-		require.EqualError(t, err, "test error")
-		m.AssertExpectations(t)
-	})
-}

--- a/mocks/framing.go
+++ b/mocks/framing.go
@@ -17,8 +17,3 @@ func (f *MockFramingLayer) Write(p []byte) error {
 	args := f.Called(p)
 	return args.Error(0)
 }
-
-func (f *MockFramingLayer) Close() error {
-	args := f.Called()
-	return args.Error(0)
-}


### PR DESCRIPTION
The framing layer does not use any resources that should be closed when the client closes except a transport. But the transport is created outside the framing layer so it should be closed outside it as well.