### PR TITLE
Extract protocols into a separated package

### DIFF
--- a/client.go
+++ b/client.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/myzhan/avroipc/protocols"
 	"github.com/myzhan/avroipc/transports"
 )
 
@@ -19,8 +20,8 @@ type client struct {
 
 	transport         transports.Transport
 	framingLayer      FramingLayer
-	callProtocol      CallProtocol
-	handshakeProtocol HandshakeProtocol
+	callProtocol      protocols.CallProtocol
+	handshakeProtocol protocols.HandshakeProtocol
 }
 
 // NewClient creates an avro Client, and connect to addr immediately
@@ -43,7 +44,7 @@ func NewClient(addr string, timeout, sendTimeout time.Duration, bufferSize, comp
 		return nil, err
 	}
 
-	proto, err := NewAvroSourceProtocol()
+	proto, err := protocols.NewAvroSourceProtocol()
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +52,7 @@ func NewClient(addr string, timeout, sendTimeout time.Duration, bufferSize, comp
 	return NewClientWithTrans(trans, proto, sendTimeout)
 }
 
-func NewClientWithTrans(trans transports.Transport, proto MessageProtocol, sendTimeout time.Duration) (Client, error) {
+func NewClientWithTrans(trans transports.Transport, proto protocols.MessageProtocol, sendTimeout time.Duration) (Client, error) {
 	var err error
 	c := &client{}
 	c.sendTimeout = sendTimeout
@@ -59,12 +60,12 @@ func NewClientWithTrans(trans transports.Transport, proto MessageProtocol, sendT
 	c.transport = trans
 	c.framingLayer = NewFramingLayer(trans)
 
-	c.callProtocol, err = NewCallProtocol(proto)
+	c.callProtocol, err = protocols.NewCallProtocol(proto)
 	if err != nil {
 		return nil, err
 	}
 
-	c.handshakeProtocol, err = NewHandshakeProtocol()
+	c.handshakeProtocol, err = protocols.NewHandshakeProtocol()
 	if err != nil {
 		return nil, err
 	}

--- a/protocols/call.go
+++ b/protocols/call.go
@@ -1,4 +1,4 @@
-package avroipc
+package protocols
 
 import (
 	"bytes"

--- a/protocols/call_test.go
+++ b/protocols/call_test.go
@@ -1,18 +1,19 @@
-package avroipc_test
+package protocols_test
 
 import (
 	"errors"
 	"testing"
 
-	"github.com/myzhan/avroipc"
 	"github.com/myzhan/avroipc/mocks"
 	"github.com/stretchr/testify/require"
+
+	"github.com/myzhan/avroipc/protocols"
 )
 
-func prepareCallProtocol(t *testing.T) (avroipc.CallProtocol, *mocks.MockProtocol) {
+func prepareCallProtocol(t *testing.T) (protocols.CallProtocol, *mocks.MockProtocol) {
 	m := &mocks.MockProtocol{}
 
-	p, err := avroipc.NewCallProtocol(m)
+	p, err := protocols.NewCallProtocol(m)
 	require.NoError(t, err)
 
 	return p, m

--- a/protocols/handshake.go
+++ b/protocols/handshake.go
@@ -1,9 +1,10 @@
-package avroipc
+package protocols
 
 import (
 	"bytes"
 	"crypto/md5"
 	"fmt"
+
 	"github.com/linkedin/goavro"
 	"github.com/sirupsen/logrus"
 )

--- a/protocols/handshake_internal_test.go
+++ b/protocols/handshake_internal_test.go
@@ -1,8 +1,9 @@
-package avroipc
+package protocols
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func Test_getMD5(t *testing.T) {

--- a/protocols/message.go
+++ b/protocols/message.go
@@ -1,7 +1,8 @@
-package avroipc
+package protocols
 
 import (
 	"fmt"
+
 	"github.com/linkedin/goavro"
 )
 

--- a/protocols/message_test.go
+++ b/protocols/message_test.go
@@ -1,9 +1,11 @@
-package avroipc_test
+package protocols_test
 
 import (
-	"github.com/myzhan/avroipc"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/myzhan/avroipc/protocols"
 )
 
 func makeDatum(body string) interface{} {
@@ -22,7 +24,7 @@ func makeArrayDatum(bodies ...string) interface{} {
 }
 
 func TestAvroSourceProtocol_PrepareMessage(t *testing.T) {
-	p, err := avroipc.NewAvroSourceProtocol()
+	p, err := protocols.NewAvroSourceProtocol()
 	require.NoError(t, err)
 
 	t.Run("bad method", func(t *testing.T) {
@@ -65,7 +67,7 @@ func TestAvroSourceProtocol_PrepareMessage(t *testing.T) {
 }
 
 func TestAvroSourceProtocol_ParseMessage(t *testing.T) {
-	p, err := avroipc.NewAvroSourceProtocol()
+	p, err := protocols.NewAvroSourceProtocol()
 	require.NoError(t, err)
 
 	t.Run("bad method", func(t *testing.T) {
@@ -95,7 +97,7 @@ func TestAvroSourceProtocol_ParseMessage(t *testing.T) {
 }
 
 func TestAvroSourceProtocol_ParseError(t *testing.T) {
-	p, err := avroipc.NewAvroSourceProtocol()
+	p, err := protocols.NewAvroSourceProtocol()
 	require.NoError(t, err)
 
 	t.Run("bad method", func(t *testing.T) {

--- a/protocols/schemas.go
+++ b/protocols/schemas.go
@@ -1,4 +1,4 @@
-package avroipc
+package protocols
 
 const errorsSchema = `
 {


### PR DESCRIPTION
This commit just continues extracting independent parts of the client code into separated packages. Now it is turn of the client protocols (messages, call and handshake protocols).