### PR TITLE
Extract the test server to a separate package, refs #20

### DIFF
--- a/internal/server.go
+++ b/internal/server.go
@@ -1,0 +1,30 @@
+package internal
+
+import (
+	"github.com/stretchr/testify/require"
+	"net"
+	"testing"
+)
+
+func RunServer(t *testing.T, handler func(net.Conn) error) (string, func() error) {
+	ln, err := net.Listen("tcp4", "127.0.0.1:0")
+	require.NoError(t, err)
+
+	accept := func() error {
+		conn, err := ln.Accept()
+		if err != nil {
+			return nil
+		}
+		defer conn.Close()
+
+		return handler(conn)
+	}
+
+	go func() {
+		for {
+			require.NoError(t, accept())
+		}
+	}()
+
+	return ln.Addr().String(), ln.Close
+}


### PR DESCRIPTION
There are plans to use the test server in other tests of the client so it will be very useful to have it in a separate package.