### PR TITLE
Remove the open method from transports

### DIFF
--- a/client.go
+++ b/client.go
@@ -74,7 +74,7 @@ func (c *client) initProtocols() error {
 }
 
 func (c *client) initTransports(addr string, config *Config) (err error) {
-	c.transport, err = transports.NewSocketTimeout(addr, config.Timeout)
+	c.transport, err = transports.NewSocket(addr, config.Timeout)
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func (c *client) initTransports(addr string, config *Config) (err error) {
 		}
 	}
 
-	return c.transport.Open()
+	return
 }
 
 func (c *client) send(request []byte) ([]byte, error) {

--- a/transports/buffered.go
+++ b/transports/buffered.go
@@ -19,10 +19,6 @@ func NewBuffered(trans Transport, bufferSize int) Transport {
 	}
 }
 
-func (p *bufferedTransport) Open() (err error) {
-	return p.trans.Open()
-}
-
 func (p *bufferedTransport) Close() (err error) {
 	return p.trans.Close()
 }

--- a/transports/buffered_test.go
+++ b/transports/buffered_test.go
@@ -19,28 +19,6 @@ func prepareBufferedTransport() (transports.Transport, *mocks.MockTransport) {
 	return b, m
 }
 
-func TestBufferedTransport_Open(t *testing.T) {
-	t.Run("succeed", func(t *testing.T) {
-		b, m := prepareBufferedTransport()
-
-		m.On("Open").Return(nil).Once()
-
-		err := b.Open()
-		require.NoError(t, err)
-		m.AssertExpectations(t)
-	})
-
-	t.Run("failed", func(t *testing.T) {
-		b, m := prepareBufferedTransport()
-
-		m.On("Open").Return(fmt.Errorf("test error")).Once()
-
-		err := b.Open()
-		require.EqualError(t, err, "test error")
-		m.AssertExpectations(t)
-	})
-}
-
 func TestBufferedTransport_Close(t *testing.T) {
 	t.Run("succeed", func(t *testing.T) {
 		b, m := prepareBufferedTransport()

--- a/transports/socket.go
+++ b/transports/socket.go
@@ -1,85 +1,29 @@
 package transports
 
 import (
-	"fmt"
 	"net"
 	"time"
 )
 
 type socket struct {
-	conn    net.Conn
-	addr    net.Addr
-	timeout time.Duration
+	net.Conn
 }
 
-func NewSocket(hostPort string) (Transport, error) {
-	return NewSocketTimeout(hostPort, 0)
-}
-
-func NewSocketTimeout(hostPort string, timeout time.Duration) (Transport, error) {
+func NewSocket(hostPort string, timeout time.Duration) (Transport, error) {
 	addr, err := net.ResolveTCPAddr("tcp", hostPort)
 	if err != nil {
 		return nil, err
 	}
 
-	return &socket{addr: addr, timeout: timeout}, nil
-}
-
-// Connects the socket, creating a new socket object if necessary.
-func (s *socket) Open() error {
-	if s.conn != nil {
-		return fmt.Errorf("already open")
-	}
-
-	conn, err := net.DialTimeout(s.addr.Network(), s.addr.String(), s.timeout)
+	s := &socket{}
+	s.Conn, err = net.DialTimeout(addr.Network(), addr.String(), timeout)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
-	s.conn = conn
-
-	return nil
-}
-
-func (s *socket) Close() error {
-	if s.conn == nil {
-		return nil
-	}
-
-	err := s.conn.Close()
-	if err != nil {
-		return err
-	}
-
-	s.conn = nil
-
-	return nil
-}
-
-func (s *socket) Read(buf []byte) (int, error) {
-	if s.conn == nil {
-		return 0, fmt.Errorf("not open")
-	}
-
-	n, err := s.conn.Read(buf)
-	fmt.Printf("R[%04d]: %X\n", n, buf[:n])
-	return n, err
-}
-
-func (s *socket) Write(buf []byte) (int, error) {
-	if s.conn == nil {
-		return 0, fmt.Errorf("not open")
-	}
-
-	n, err := s.conn.Write(buf)
-	fmt.Printf("W[%04d]: %X\n", n, buf)
-	return n, err
+	return s, nil
 }
 
 func (s *socket) Flush() error {
 	return nil
-}
-
-func (s *socket) SetDeadline(d time.Time) error {
-	return s.conn.SetDeadline(d)
 }

--- a/transports/transport.go
+++ b/transports/transport.go
@@ -8,7 +8,6 @@ import (
 type Transport interface {
 	io.ReadWriteCloser
 
-	Open() error
 	Flush() error
 	SetDeadline(t time.Time) error
 }

--- a/transports/zlib.go
+++ b/transports/zlib.go
@@ -24,10 +24,6 @@ func NewZlib(trans Transport, level int) (Transport, error) {
 	}, nil
 }
 
-func (t *zlibTransport) Open() error {
-	return t.trans.Open()
-}
-
 func (t *zlibTransport) Close() error {
 	if t.r != nil {
 		err := t.r.Close()


### PR DESCRIPTION
The original design with the Open method and the possibility to postpone opening a connection to a Flume endpoint looks not so useful now and just produces many additional and unnecessary code. Removing such feature simplifies the code and makes it more clear.