### PR TITLE
Flush data from buffer on closing

### DIFF
--- a/transports/buffered.go
+++ b/transports/buffered.go
@@ -19,7 +19,11 @@ func NewBuffered(trans Transport, bufferSize int) Transport {
 	}
 }
 
-func (p *bufferedTransport) Close() (err error) {
+func (p *bufferedTransport) Close() error {
+	err := p.w.Flush()
+	if err != nil {
+		return err
+	}
 	return p.trans.Close()
 }
 

--- a/transports/buffered_test.go
+++ b/transports/buffered_test.go
@@ -20,7 +20,7 @@ func prepareBufferedTransport() (transports.Transport, *mocks.MockTransport) {
 }
 
 func TestBufferedTransport_Close(t *testing.T) {
-	t.Run("succeed", func(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
 		b, m := prepareBufferedTransport()
 
 		m.On("Close").Return(nil).Once()
@@ -37,6 +37,21 @@ func TestBufferedTransport_Close(t *testing.T) {
 
 		err := b.Close()
 		require.EqualError(t, err, "test error")
+		m.AssertExpectations(t)
+	})
+
+	t.Run("flush data in a buffer", func(t *testing.T) {
+		d := []byte{0x00, 0x00}
+		b, m := prepareBufferedTransport()
+
+		m.On("Write", d).Return(len(d), nil).Once()
+		m.On("Close").Return(nil).Once()
+
+		_, err := b.Write(d)
+		require.NoError(t, err)
+		err = b.Close()
+		require.NoError(t, err)
+
 		m.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
Now there is a bug with the buffered transport and if there are some bytes in the buffer before closing the transport they will be silently ignored. It does not create any problem with communication with a Flume server because there is no closing procedure and we can just loose only some unnecessary data of zlib transport. That's all.